### PR TITLE
Fixing compile and golangci lint errors probably due to aws libs updated

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -25,12 +26,12 @@ func ListMFADevices(awsConfig aws.Config) ([]string, error) {
 		UserName: aws.String(splits[1]),
 	})
 
-	resp, err := req.Send()
+	resp, err := req.Send(context.Background())
 	if err != nil {
 		return nil, err
 	}
 
-	return displayMFADevices(resp), nil
+	return displayMFADevices(resp.ListMFADevicesOutput), nil
 }
 
 func displayMFADevices(output *iam.ListMFADevicesOutput) []string {

--- a/cmd/sts.go
+++ b/cmd/sts.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -32,7 +33,7 @@ func GetSessionToken(awsConfig aws.Config, duration int64, device string, code s
 		TokenCode:       aws.String(code),
 	})
 
-	resp, err := req.Send()
+	resp, err := req.Send(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +59,7 @@ func getCurrentUserARN(awsConfig aws.Config) (string, error) {
 	service := sts.New(awsConfig)
 	req := service.GetCallerIdentityRequest(&sts.GetCallerIdentityInput{})
 
-	resp, err := req.Send()
+	resp, err := req.Send(context.Background())
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>

When installing `aws-mfa` with the command `got get -u ....` , I had some errors.

I tried to fix it here, let me know what you think about this?